### PR TITLE
Support 10.3 LTS

### DIFF
--- a/cpji-jira-plugin-test/pom.xml
+++ b/cpji-jira-plugin-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>cpji-jira</artifactId>
         <groupId>com.atlassian.cpji</groupId>
-		<version>10.0.0</version>
+		<version>10.1.0</version>
     </parent>
     <artifactId>cpji-jira-plugin-test</artifactId>
     <name>Remote copying of issues - Integration Tests</name>

--- a/cpji-jira-plugin/pom.xml
+++ b/cpji-jira-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>cpji-jira</artifactId>
         <groupId>com.atlassian.cpji</groupId>
-		<version>10.0.0</version>
+		<version>10.1.0</version>
     </parent>
 
     <artifactId>cpji-jira-plugin</artifactId>

--- a/cpji-jira-plugin/src/main/java/com/atlassian/cpji/rest/model/CopyInformationBean.java
+++ b/cpji-jira-plugin/src/main/java/com/atlassian/cpji/rest/model/CopyInformationBean.java
@@ -2,6 +2,7 @@ package com.atlassian.cpji.rest.model;
 
 import com.google.common.collect.Lists;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.annotate.JsonProperty;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
@@ -33,6 +34,9 @@ public class CopyInformationBean {
 
 	@XmlElement
 	private UserBean user;
+
+	@XmlElement
+	private UserBean remoteUser;
 
 	@XmlElement
 	private boolean hasCreateLinksPermission;

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.atlassian.cpji</groupId>
     <artifactId>cpji-jira</artifactId>
-    <version>10.0.0</version>
+    <version>10.1.0</version>
     <name>Remote copying of issues - Parent POM</name>
     <packaging>pom</packaging>
 
@@ -32,7 +32,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <cpji.build.directory>target</cpji.build.directory>
         <!--Downgrading Jira version requires a change in used datasets. See <dataPath> properties in specific module poms.-->
-        <jira.version>10.1.1</jira.version>
+        <jira.version>10.3.1</jira.version>
         <jira.compile.version>${jira.version}</jira.compile.version>
         <jira.data.version>${jira.version}</jira.data.version>
         <spring.version>5.1.18.RELEASE</spring.version>


### PR DESCRIPTION
The new Jira LTS is 10.3. We recently installed 10.3.1 and found that version 10.0.0 of the plugin does not work on 10.3.1, causing a stack trace on attempt to copy. The changes in this PR fix the stack trace cause and update the plugin to build for Jira 10.3.1.
