### PR TITLE
fix: explicitly define maven and ehcache packages

### DIFF
--- a/cpji-jira-plugin-test/pom.xml
+++ b/cpji-jira-plugin-test/pom.xml
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.2.1-atlassian-2</version>
+			<version>${apache.httpclient.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/cpji-jira-plugin-test/pom.xml
+++ b/cpji-jira-plugin-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>cpji-jira</artifactId>
         <groupId>com.atlassian.cpji</groupId>
-		<version>10.1.0</version>
+		<version>10.1.1</version>
     </parent>
     <artifactId>cpji-jira-plugin-test</artifactId>
     <name>Remote copying of issues - Integration Tests</name>

--- a/cpji-jira-plugin/pom.xml
+++ b/cpji-jira-plugin/pom.xml
@@ -14,14 +14,51 @@
     <description>Plugin that copies issues from one JIRA instance to another</description>
     <packaging>atlassian-plugin</packaging>
 
+	<repositories>
+		<repository>
+			<id>central</id>
+			<name>Maven Central</name>
+			<url>https://repo1.maven.org/maven2</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+		<repository>
+			<id>atlassian-public</id>
+			<name>Atlassian Public Repository</name>
+			<url>https://maven.atlassian.com/repository/public</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+
 	<dependencies>
 		<dependency>
 			<groupId>com.atlassian.jira</groupId>
 			<artifactId>jira-api</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>net.sf.ehcache</groupId>
+					<artifactId>ehcache</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.atlassian.jira</groupId>
 			<artifactId>jira-core</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>net.sf.ehcache</groupId>
+					<artifactId>ehcache</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<!-- REST dependencies-->
 		<dependency>

--- a/cpji-jira-plugin/pom.xml
+++ b/cpji-jira-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>cpji-jira</artifactId>
         <groupId>com.atlassian.cpji</groupId>
-		<version>10.1.0</version>
+		<version>10.1.1</version>
     </parent>
 
     <artifactId>cpji-jira-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -258,18 +258,4 @@
         <tag>cpji-jira-10.0.0</tag>
     </scm>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>scala</id>
-            <name>Scala Tools</name>
-            <url>http://scala-tools.org/repo-releases/</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </pluginRepository>
-    </pluginRepositories>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.atlassian.cpji</groupId>
     <artifactId>cpji-jira</artifactId>
-    <version>10.1.0</version>
+    <version>10.1.1</version>
     <name>Remote copying of issues - Parent POM</name>
     <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <spring.version>5.1.18.RELEASE</spring.version>
         <guava.version>26.0-jre</guava.version>
         <commons.lang3.version>3.9</commons.lang3.version>
-        <apache.httpclient.version>4.5.13</apache.httpclient.version>
+        <apache.httpclient.version>4.5.14</apache.httpclient.version>
         <apache.httpcore.version>4.4.12</apache.httpcore.version>
         <apache.httpasyncclient.version>4.1</apache.httpasyncclient.version>
         <atlassian.httpclient.version>2.1.5</atlassian.httpclient.version>
@@ -58,6 +58,7 @@
         <failOnMilestoneOrReleaseCandidateDeps>true</failOnMilestoneOrReleaseCandidateDeps>
         <rest.doc.generation.skip>true</rest.doc.generation.skip>
         <jira.rest.client.version>5.2.2</jira.rest.client.version>
+        <jettison.version>1.5.4</jettison.version>
     </properties>
 
     <dependencyManagement>
@@ -176,7 +177,7 @@
             <dependency>
                 <groupId>org.codehaus.jettison</groupId>
                 <artifactId>jettison</artifactId>
-                <version>1.1</version>
+                <version>${jettison.version}</version>
                 <scope>compile</scope>
             </dependency>
 
@@ -185,7 +186,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.0</version>
+                <version>4.5.14</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
This corrects a build error where plugin provisioning was failing. 

- chore: bump package version to address vulnerabilities